### PR TITLE
Replaced use of deprecated set-output in entrypoint.py

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -7,6 +7,7 @@
 # if you use pyaction:4.0.0 or higher as your base docker image.
 
 import sys
+import os
 
 if __name__ == "__main__" :
     # Rename these variables to something meaningful
@@ -18,7 +19,9 @@ if __name__ == "__main__" :
     output1 = "Hello"
     output2 = "World"
 
-    # This is how you produce outputs.
+    # This is how you produce workflow outputs.
     # Make sure corresponds to output variable names in action.yml
-    print("::set-output name=output-one::" + output1)
-    print("::set-output name=output-two::" + output2)
+    if "GITHUB_OUTPUT" in os.environ :
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f :
+            print("{0}={1}".format("output-one", output1), file=f)
+            print("{0}={1}".format("output-two", output2), file=f)


### PR DESCRIPTION
## Summary
Replaced use of deprecated set-output in entrypoint.py

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
