### PR TITLE
Removed the extra space characters at end of lines in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding: # Look at documentation for branding options/requirements. These are m
   icon: 'book-open'
   color: 'green'
 inputs:
-  input-one:  
+  input-one:
     description: 'Description of input-one'
     required: false
     default: 'default value goes here'
@@ -18,7 +18,7 @@ outputs:
   output-one:
     description: 'Description of output-one'
   output-two:
-    description: 'Description of output-two'	
+    description: 'Description of output-two'
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
## Summary
Removes extra space characters at end of two lines in `action.yml`. This is purely a stylistic change.

## Closing Issues
Closes #13 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
